### PR TITLE
Better detection of environment

### DIFF
--- a/src/detect-environment.coffee
+++ b/src/detect-environment.coffee
@@ -1,0 +1,4 @@
+module.exports = if process?.browser or (window? and not process?)
+  'browser'
+else
+  'node'

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -24,9 +24,7 @@ makeHTTPRequest = (method, url, data, headers = {}, modify) ->
             when 'delete' then request.del(url)
 
     req = req.set headers
-
-    if env is 'browser'
-      req = req.withCredentials()
+    req = req.withCredentials() if req.withCredentials?
 
     req = modify request if modify?
 

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -1,10 +1,10 @@
 request = require 'superagent'
-
-unless window?
-  request = request.agent()
-
 coreUrl = require 'url'
 corePath = require 'path'
+env = require './detect-environment'
+
+if env is 'node'
+  request = request.agent()
 
 makeHTTPRequest = (method, url, data, headers = {}, modify) ->
   originalArguments = Array::slice.call arguments # In case we need to retry
@@ -25,7 +25,7 @@ makeHTTPRequest = (method, url, data, headers = {}, modify) ->
 
     req = req.set headers
 
-    if window?
+    if env is 'browser'
       req = req.withCredentials()
 
     req = modify request if modify?


### PR DESCRIPTION
Flailing a bit here, but this handles the environments I could test.

Browserify sets process.browser to true. Normal browser env defines window, but not process. Electron has both window and process defined.
